### PR TITLE
Add OS dependency flag to package.json to allow inclusion on other platforms

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "bindings": "~1.1.1",
     "nan": "~1.1.0"
   },
+  "os": [ "linux" ],
   "devDependencies": {},
   "optionalDependencies": {}
 }


### PR DESCRIPTION
I was using a node module that optionally includes node-abstract socket. On OS X, node-abstractsocket gets a compile error. Specifying the OS requirement in node-abstractsocket's package.json file allows it to skip trying to build on OS X.