### PR TITLE
Update nan version

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "bindings": "~1.1.1",
-    "nan": "~1.1.0"
+    "nan": "~1.7.0"
   },
   "os": [ "linux" ],
   "devDependencies": {},


### PR DESCRIPTION
nan version ~1.1.0 didn't compile with Atom, so I updated the version number to the current version (~1.7.0).

Now it seems to compile with both Atom and Node.