### PR TITLE
Update project to match `net` library's behaviour

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+build
+

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,17 @@
+{
+    "esnext": true,
+    "node": true,
+    "unused": true,
+    "undef": true,
+    "newcap": false,
+    "varstmt": true,
+    "predef": [
+        "describe",
+        "it",
+        "beforeEach",
+        "before",
+        "afterEach",
+        "after"
+    ]
+}
+

--- a/README.md
+++ b/README.md
@@ -62,13 +62,13 @@ it passing the name of the abstract socket to bind to and listen, it follows
 the API used for normal Unix domain sockets. NOTE: you must prepend the path with
 the NULL byte ('\0') to indicate it's an abstract socket.
 
-Throws an exception if the `socket(2)` system call fails.
+Emits an error if the `socket(2)` system call fails.
 
 ### AbstractSocketServer.listen(name, [callback]
 
 Binds the server to the specified abstract socket name.
 
-Throws an exception if the `bind(2)` system call fails, or the given `name`
+Emits an error if the `bind(2)` system call fails, or the given `name`
 is invalid.
 
 This function is asynchronous. When the server has been bound, 'listening' event
@@ -81,11 +81,14 @@ Creates a connection to the given `path` in the abstract domain. NOTE: you must
 prepend the path with the NULL byte ('\0') to indicate it's an abstract
 socket.
 
-Returns a new and connected net.Socket object.
+Returns a new net.Socket object.
 
-Throws an exception if the `socket(2)` or `connect(2)` system calls fail,
+Emits an error if the `socket(2)` or `connect(2)` system calls fail,
 or the given `name` is invalid.
 
+## Tests
+
+Run tests with `npm test`.
 
 ## Thanks
 

--- a/examples/client.js
+++ b/examples/client.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const client = require('../lib/abstract_socket')
+const client = require('../lib/abstract_socket.js')
     .connect('\0foo2', () => { //'connect' listener
         console.log('client connected');
     })

--- a/examples/client.js
+++ b/examples/client.js
@@ -1,17 +1,23 @@
 'use strict';
-const abs = require('./lib/abstract_socket');
 
-const client = abs.connect('\0foo2', function() { //'connect' listener
-    console.log('client connected');
-});
+const client = require('../lib/abstract_socket')
+    .connect('\0foo2', () => { //'connect' listener
+        console.log('client connected');
+    })
+    .on('data', data => {
+        console.log(data.toString());
+    })
+    .on('error', err => {
+        console.log('caught', err);
+    })
+    .on('end', () => {
+        console.log('client ended');
+    });
 
-client.on('data', function(data) {
-    console.log(data.toString());
-});
+process.stdin.setEncoding('utf8')
+    .on('readable', () => {
+        const chunk = process.stdin.read();
+        if (chunk !== null)
+            client.write(chunk);
+    });
 
-process.stdin.setEncoding('utf8');
-process.stdin.on('readable', function() {
-    const chunk = process.stdin.read();
-    if (chunk !== null)
-        client.write(chunk);
-});

--- a/examples/client.js
+++ b/examples/client.js
@@ -1,0 +1,17 @@
+'use strict';
+const abs = require('./lib/abstract_socket');
+
+const client = abs.connect('\0foo2', function() { //'connect' listener
+    console.log('client connected');
+});
+
+client.on('data', function(data) {
+    console.log(data.toString());
+});
+
+process.stdin.setEncoding('utf8');
+process.stdin.on('readable', function() {
+    const chunk = process.stdin.read();
+    if (chunk !== null)
+        client.write(chunk);
+});

--- a/examples/server.js
+++ b/examples/server.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('../lib/abstract_socket')
+require('../lib/abstract_socket.js')
     .createServer(client => {
         console.log('client connected');
         client.on('end', () => {

--- a/examples/server.js
+++ b/examples/server.js
@@ -9,5 +9,8 @@ require('../lib/abstract_socket')
             .pipe(client)
             .write('hello from server\r\n');
     })
+    .on('error', err => {
+        console.log('server error', err);
+    })
     .listen('\0foo2');
 

--- a/examples/server.js
+++ b/examples/server.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const abs = require('./lib/abstract_socket');
+
+const server = abs.createServer(function(c) { //'connection' listener
+    console.log('client connected');
+    c.on('end', function() {
+        console.log('client disconnected');
+    });
+    c.write('hello\r\n');
+    c.pipe(c);
+});
+server.listen('\0foo2');
+

--- a/examples/server.js
+++ b/examples/server.js
@@ -1,14 +1,13 @@
 'use strict';
 
-const abs = require('./lib/abstract_socket');
-
-const server = abs.createServer(function(c) { //'connection' listener
-    console.log('client connected');
-    c.on('end', function() {
-        console.log('client disconnected');
-    });
-    c.write('hello\r\n');
-    c.pipe(c);
-});
-server.listen('\0foo2');
+require('../lib/abstract_socket')
+    .createServer(client => {
+        console.log('client connected');
+        client.on('end', () => {
+            console.log('client disconnected');
+        })
+            .pipe(client)
+            .write('hello from server\r\n');
+    })
+    .listen('\0foo2');
 

--- a/lib/abstract_socket.js
+++ b/lib/abstract_socket.js
@@ -8,7 +8,6 @@ const bind    = binding.bind;
 const connect = binding.connect;
 const close   = binding.close;
 
-
 function errnoException(errorno, syscall) {
     // TODO: having the errno message here would be nice
     const e = new Error(syscall + ' ' + errorno);

--- a/lib/abstract_socket.js
+++ b/lib/abstract_socket.js
@@ -68,7 +68,9 @@ exports.connect = exports.createConnection = function(name, connectListener) {
     }
 
     const sock = new net.Socket(options);
-    setImmediate(() => connectListener(sock));
+    if ('function' === typeof connectListener) {
+        setImmediate(() => connectListener(sock));
+    }
     return sock;
 };
 

--- a/lib/abstract_socket.js
+++ b/lib/abstract_socket.js
@@ -1,57 +1,56 @@
+'use strict';
 
-var net = require('net');
-var util = require('util');
-var binding = require('bindings')('abstract_socket.node');
+const net = require('net');
+const binding = require('bindings')('abstract_socket.node');
 
-var socket  = binding.socket;
-var bind    = binding.bind;
-var connect = binding.connect;
-var close   = binding.close;
+const socket  = binding.socket;
+const bind    = binding.bind;
+const connect = binding.connect;
+const close   = binding.close;
 
 
 function errnoException(errorno, syscall) {
     // TODO: having the errno message here would be nice
-    var e = new Error(syscall + ' ' + errorno);
+    const e = new Error(syscall + ' ' + errorno);
     e.errno = e.code = errorno;
     e.syscall = syscall;
     return e;
 }
 
-
-function AbstractSocketServer(connectionListener) {
-    net.Server.call(this, connectionListener);
-}
-util.inherits(AbstractSocketServer, net.Server);
-
-
-AbstractSocketServer.prototype.listen = function(name, listeningListener) {
-    var err = socket();
-    if (err < 0)
-        throw errnoException(err, 'socket');
-
-    var handle = {fd: err};
-
-    err = bind(err, name);
-    if (err < 0) {
-        close(handle.fd);
-        throw errnoException(err, 'bind');
+class AbstractSocketServer extends net.Server {
+    constructor(listener) {
+        super(listener);
     }
 
-    net.Server.prototype.listen.call(this, handle, listeningListener);
+    listen(name, listener) {
+        let err = socket();
+        if (err < 0) {
+            throw errnoException(err, 'socket');
+        }
+
+        const handle = {fd: err};
+
+        err = bind(err, name);
+        if (err < 0) {
+            close(handle.fd);
+            throw errnoException(err, 'bind');
+        }
+        super.listen(handle, listener);
+    }
+}
+
+exports.createServer = function(listener) {
+    return new AbstractSocketServer(listener);
 };
 
 
-exports.createServer = function(connectionListener) {
-    return new AbstractSocketServer(connectionListener);
-};
-
-
-exports.connect = function(name, connectListener) {
-    var err = socket();
-    if (err < 0)
+exports.connect = exports.createConnection = function(name, connectListener) {
+    let err = socket();
+    if (err < 0) {
         throw errnoException(err, 'socket');
+    }
 
-    var options = {fd: err, readable: true, writable: true};
+    const options = {fd: err, readable: true, writable: true};
 
     // yes, connect is synchronous, so sue me
     err = connect(err, name);
@@ -60,8 +59,8 @@ exports.connect = function(name, connectListener) {
         throw errnoException(err, 'connect');
     }
 
-    return new net.Socket(options);
+    const sock = new net.Socket(options);
+    setImmediate(() => connectListener(sock));
+    return sock;
 };
-
-exports.createConnection = exports.connect;
 

--- a/lib/abstract_socket.js
+++ b/lib/abstract_socket.js
@@ -43,20 +43,28 @@ exports.createServer = function(listener) {
     return new AbstractSocketServer(listener);
 };
 
-
 exports.connect = exports.createConnection = function(name, connectListener) {
+    const defaultOptions = {
+        readable: true,
+        writable: true
+    };
+
     let err = socket();
     if (err < 0) {
-        throw errnoException(err, 'socket');
+        const sock = new net.Socket(defaultOptions);
+        setImmediate(() => sock.emit('error', errnoException(err, 'socket')));
+        return sock;
     }
 
-    const options = {fd: err, readable: true, writable: true};
+    const options = Object.assign({fd: err}, defaultOptions);
 
     // yes, connect is synchronous, so sue me
     err = connect(err, name);
     if (err < 0) {
         close(options.fd);
-        throw errnoException(err, 'connect');
+        const sock = new net.Socket(defaultOptions);
+        setImmediate(() => sock.emit('error', errnoException(err, 'connect')));
+        return sock;
     }
 
     const sock = new net.Socket(options);

--- a/lib/abstract_socket.js
+++ b/lib/abstract_socket.js
@@ -25,7 +25,7 @@ class AbstractSocketServer extends net.Server {
     listen(name, listener) {
         let err = socket();
         if (err < 0) {
-            throw errnoException(err, 'socket');
+            this.emit(errnoException(err, 'socket'));
         }
 
         const handle = {fd: err};
@@ -33,7 +33,7 @@ class AbstractSocketServer extends net.Server {
         err = bind(err, name);
         if (err < 0) {
             close(handle.fd);
-            throw errnoException(err, 'bind');
+            this.emit(errnoException(err, 'bind'));
         }
         super.listen(handle, listener);
     }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
         "url": "http://bettercallsaghul.com"
     },
     "scripts": {
-        "test": "./node_modules/.bin/mocha --growl --timeout 2000 test/*.test.js"
+        "test": "./node_modules/.bin/mocha --growl --timeout 10000 test/*.test.js"
     },
     "name": "abstract-socket",
     "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
         "email": "saghul@gmail.com",
         "url": "http://bettercallsaghul.com"
     },
+    "scripts": {
+        "test": "./node_modules/.bin/mocha --growl --timeout 2000 test/*.test.js"
+    },
     "name": "abstract-socket",
     "version": "1.1.0",
     "description": "Abstract domain socket support for Node / io.js",
@@ -20,6 +23,10 @@
     "dependencies": {
         "bindings": "^1.2.1",
         "nan": "^2.0.9"
+    },
+    "devDependencies": {
+        "should": "8.2.x",
+        "mocha": "2.4.x"
     },
     "os": [
         "linux"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "test": "./node_modules/.bin/mocha --growl --timeout 10000 test/*.test.js"
     },
     "name": "abstract-socket",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "description": "Abstract domain socket support for Node / io.js",
     "main": "lib/abstract_socket",
     "homepage": "https://github.com/saghul/node-abstractsocket",

--- a/package.json
+++ b/package.json
@@ -1,27 +1,28 @@
 {
-  "author": {
-    "name": "Saúl Ibarra Corretgé",
-    "email": "saghul@gmail.com",
-    "url": "http://bettercallsaghul.com"
-  },
-  "name": "abstract-socket",
-  "version": "1.1.0",
-  "description": "Abstract domain socket support for Node / io.js",
-  "main": "lib/abstract_socket",
-  "homepage": "https://github.com/saghul/node-abstractsocket",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/saghul/node-abstractsocket.git"
-  },
-  "engines": {
-    "node": ">=0.10.0"
-  },
-  "dependencies": {
-    "bindings": "^1.2.1",
-    "nan": "^2.0.9"
-  },
-  "os": [
-    "linux"
-  ]
+    "author": {
+        "name": "Saúl Ibarra Corretgé",
+        "email": "saghul@gmail.com",
+        "url": "http://bettercallsaghul.com"
+    },
+    "name": "abstract-socket",
+    "version": "1.1.0",
+    "description": "Abstract domain socket support for Node / io.js",
+    "main": "lib/abstract_socket",
+    "homepage": "https://github.com/saghul/node-abstractsocket",
+    "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/saghul/node-abstractsocket.git"
+    },
+    "engines": {
+        "node": ">=0.10.0"
+    },
+    "dependencies": {
+        "bindings": "^1.2.1",
+        "nan": "^2.0.9"
+    },
+    "os": [
+        "linux"
+    ]
 }
+

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "url": "git://github.com/saghul/node-abstractsocket.git"
     },
     "engines": {
-        "node": ">=0.10.0"
+        "node": ">=4.0.0"
     },
     "dependencies": {
         "bindings": "^1.2.1",

--- a/test/abstract-socket.test.js
+++ b/test/abstract-socket.test.js
@@ -1,0 +1,142 @@
+'use strict';
+
+const spawn = require('child_process').spawn;
+const should = require('should'); // jshint ignore: line
+const abs = require('../lib/abstract_socket.js');
+
+const SOCKET_NAME = '\0test312';
+const SOME_DATA = 'asdqq\n';
+
+describe('server', () => {
+    describe('listening', () => {
+        let server;
+        beforeEach(() => (server = abs.createServer()) && server.listen(SOCKET_NAME));
+        afterEach(() => server.close());
+
+        it('should listen on abstract socket', () => exec('lsof -U')
+            .then(output => output.should.containEql(`@${SOCKET_NAME.slice(1)}`)));
+
+        it('should emit error when socket is busy', done => {
+            const server = abs.createServer();
+            server.listen(SOCKET_NAME);
+            server.on('error', err => {
+                err.syscall.should.equal('listen');
+                done();
+            });
+        });
+    });
+
+    describe('client connections', () => {
+        let server;
+        beforeEach(() => (server = abs.createServer()) && server.listen(SOCKET_NAME));
+        afterEach(() => server.close());
+
+        it('should emit event when client connects', done => {
+            server.on('connection', () => done());
+            abs.connect(SOCKET_NAME);
+        });
+
+        it('should receive client data', done => {
+            server.on('connection', client => {
+                client.on('data', data => {
+                    data.toString().should.equal(SOME_DATA);
+                    done();
+                });
+            });
+            abs.connect(SOCKET_NAME).write(SOME_DATA);
+        });
+    });
+
+    describe('messages', () => {
+        let server;
+        beforeEach(() => (server = abs.createServer()) && server.listen(SOCKET_NAME));
+        afterEach(() => server.close());
+
+        it('should be received from the client', done => {
+            server.on('connection', client => {
+                client.on('data', data => {
+                    data.toString().should.equal(SOME_DATA);
+                    done();
+                });
+            });
+            const client = abs.connect(SOCKET_NAME, () => {
+                client.write(SOME_DATA);
+            });
+        });
+    });
+});
+
+describe('client', () => {
+    describe('should emit error', () => {
+        it('when connecting to a non existent socket', done => {
+            abs.connect('\0non-existent-socket').on('error', () => done());
+        });
+
+        it('when connecting to a non abstract socket', done => {
+            abs.connect('non-abstract-socket').on('error', () => done());
+        });
+    });
+
+    describe('connect callback', () => {
+        let server;
+        beforeEach(() => (server = abs.createServer()) && server.listen(SOCKET_NAME));
+        afterEach(() => server.close());
+
+        it('should be called when connected', done => {
+            abs.connect(SOCKET_NAME, () => done());
+        });
+
+        it('should be called asynchronously', done => {
+            let counter = 0;
+            abs.connect(SOCKET_NAME, () => {
+                counter.should.equal(1);
+                done();
+            });
+            ++counter;
+        });
+    });
+
+    describe('messages', () => {
+        let server;
+        beforeEach(() => (server = abs.createServer()) && server.listen(SOCKET_NAME));
+        afterEach(() => server.close());
+
+        it('should be sent to the server', done => {
+            server.on('connection', client => {
+                client.on('data', data => {
+                    data.toString().should.equal(SOME_DATA);
+                    done();
+                });
+            });
+            const client = abs.connect(SOCKET_NAME, () => {
+                client.write(SOME_DATA);
+            });
+        });
+    });
+});
+
+function exec(cmd, options) {
+    return new Promise((resolve, reject) => {
+        let bin = cmd.split(' ').shift();
+        let params = cmd.split(' ').slice(1);
+        let child = spawn(bin, params, options);
+        let res = new Buffer(0);
+        let err = new Buffer(0);
+
+        child.stdout.on('data', buf => res = Buffer.concat([res, buf], res.length + buf.length));
+        child.stderr.on('data', buf => err = Buffer.concat([err, buf], err.length + buf.length));
+        child.on('close', code => {
+            return setImmediate(() => {
+                // setImmediate is required because there are often still
+                // pending write requests in both stdout and stderr at this point
+                if (code) {
+                    reject(err.toString());
+                } else {
+                    resolve(res.toString());
+                }
+            });
+        });
+        child.on('error', reject);
+    });
+}
+

--- a/test/abstract-socket.test.js
+++ b/test/abstract-socket.test.js
@@ -24,6 +24,12 @@ describe('server', function() {
                 done();
             });
         });
+
+        it('should stop listening when close is called', () => new Promise(resolve => {
+            server.close(resolve);
+        })
+            .then(() => exec('lsof -U'))
+            .then(output => output.should.not.containEql(`@${SOCKET_NAME.slice(1)}`)));
     });
 
     describe('client connections', function() {


### PR DESCRIPTION
There's quite a handful of changes here:
- ES6 coding style
- Socket objects always returned by client calls
- Listeners called asynchronously with setImmediate
- `"error"` events emitted by each server and socket instance instead of errors thrown
- Fixed `connectListener` never called
- Copied README's examples to `examples` directory so they can be executed
- Added tests
