### PR TITLE
Make sure connection listener gets called

### DIFF
--- a/lib/abstract_socket.js
+++ b/lib/abstract_socket.js
@@ -59,8 +59,9 @@ exports.connect = function(name, connectListener) {
         close(options.fd);
         throw errnoException(err, 'connect');
     }
-
-    return new net.Socket(options);
+    var sock = new net.Socket(options);
+    setImmediate(() => connectListener(sock));
+    return sock;
 };
 
 exports.createConnection = exports.connect;


### PR DESCRIPTION
This change makes sure connection listener on `connect` gets called as shown in the documentation in the main `README.md`