### PR TITLE
fix: use Nan::GetFunction for compatibility with v8 7.4

### DIFF
--- a/src/abstract_socket.cc
+++ b/src/abstract_socket.cc
@@ -166,13 +166,13 @@ NAN_METHOD(Close) {
 
 void Initialize(Local<Object> target) {
     target->Set(Nan::New("socket").ToLocalChecked(),
-                Nan::New<FunctionTemplate>(Socket)->GetFunction());
+                Nan::GetFunction(Nan::New<FunctionTemplate>(Socket)).ToLocalChecked());
     target->Set(Nan::New("bind").ToLocalChecked(),
-                Nan::New<FunctionTemplate>(Bind)->GetFunction());
+                Nan::GetFunction(Nan::New<FunctionTemplate>(Bind)).ToLocalChecked());
     target->Set(Nan::New("connect").ToLocalChecked(),
-                Nan::New<FunctionTemplate>(Connect)->GetFunction());
+                Nan::GetFunction(Nan::New<FunctionTemplate>(Connect)).ToLocalChecked());
     target->Set(Nan::New("close").ToLocalChecked(),
-                Nan::New<FunctionTemplate>(Close)->GetFunction());
+                Nan::GetFunction(Nan::New<FunctionTemplate>(Close)).ToLocalChecked());
 }
 
 


### PR DESCRIPTION
https://github.com/nodejs/nan/blob/master/doc/maybe_types.md#api_nan_get_function

v8 7.4 has deleted the deprecated non-maybe version of `FunctionTemplate::GetFunction`. This Nan API should work on the new version of v8 though :)